### PR TITLE
Add GitHub Actions CI for Build & Release and Update Publish Profile for .NET 8

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,21 +15,25 @@ jobs:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '7.0.x'
+          dotnet-version: '8.0.x'
           
       - name: Restore dependencies
         run: dotnet restore Chitti/Chitti.csproj
         
       - name: Publish using .pubxml
         run: dotnet publish Chitti/Chitti.csproj -p:PublishProfile=FolderProfile1
-          
+
+      - name: Rename executable with architecture
+        run: |
+          Copy-Item "Chitti/bin/Release/net7.0-windows/win-x86/publish/Chitti.exe" "Chitti/bin/Release/net7.0-windows/win-x86/publish/Chitti-win-x86.exe"
+              
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
           name: Chitti Release ${{ github.ref_name }}
           tag_name: ${{ github.ref_name }}
           files: |
-            Chitti/bin/Release/net7.0-windows/win-x86/publish/Chitti.exe
+            Chitti/bin/Release/net7.0-windows/win-x86/publish/Chitti-win-x86.exe
           body: |
             ## Chitti Release ${{ github.ref_name }}
             

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,49 @@
+name: Build and Release Chitti
+on:
+  push:
+    tags:
+      - 'v*'  # e.g., v1.0.0
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '7.0.x'
+          
+      - name: Restore dependencies
+        run: dotnet restore Chitti/Chitti.csproj
+        
+      - name: Publish using .pubxml
+        run: dotnet publish Chitti/Chitti.csproj -p:PublishProfile=FolderProfile1
+          
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: Chitti Release ${{ github.ref_name }}
+          tag_name: ${{ github.ref_name }}
+          files: |
+            Chitti/bin/Release/net7.0-windows/win-x86/publish/Chitti.exe
+          body: |
+            ## Chitti Release ${{ github.ref_name }}
+            
+            ### What's New
+            - Automated build and release
+            
+            ### Installation
+            1. Download `Chitti.exe`
+            2. Run the executable directly (no installation required)
+            
+            ### System Requirements
+            - Windows 10/11
+            - x64 architecture
+          draft: false
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Chitti/Properties/PublishProfiles/FolderProfile1.pubxml
+++ b/Chitti/Properties/PublishProfiles/FolderProfile1.pubxml
@@ -6,7 +6,7 @@
     <PublishDir>bin\Release\net7.0-windows\win-x86\publish\</PublishDir>
     <PublishProtocol>FileSystem</PublishProtocol>
     <_TargetId>Folder</_TargetId>
-    <TargetFramework>net7.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <RuntimeIdentifier>win-x86</RuntimeIdentifier>
     <SelfContained>true</SelfContained>
   </PropertyGroup>

--- a/Chitti/Properties/PublishProfiles/FolderProfile1.pubxml
+++ b/Chitti/Properties/PublishProfiles/FolderProfile1.pubxml
@@ -1,10 +1,9 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- https://go.microsoft.com/fwlink/?LinkID=208121. -->
+<?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
     <Configuration>Release</Configuration>
     <Platform>Any CPU</Platform>
-    <PublishDir>bin\Release\net7.0-windows\win-x64\publish\win-x86\</PublishDir>
+    <PublishDir>bin\Release\net7.0-windows\win-x86\publish\</PublishDir>
     <PublishProtocol>FileSystem</PublishProtocol>
     <_TargetId>Folder</_TargetId>
     <TargetFramework>net7.0-windows</TargetFramework>


### PR DESCRIPTION

**Title:**  
Add GitHub Actions CI for Build & Release and Update Publish Profile for .NET 8

**Description:**  
### Summary of Changes

- **Added GitHub Actions CI/CD Workflow**
  - Introduced `.github/workflows/main.yml` to automate building and releasing Chitti.
  - Workflow triggers on version tags (`v*`) and manual dispatch.
  - Workflow steps:
    - Checks out code, sets up .NET 8 SDK.
    - Restores dependencies and publishes using the FolderProfile1 profile.
    - Renames the executable for clarity.
    - Creates a GitHub release with the built executable attached.

- **Updated Publish Profile**
  - Updated `Chitti/Properties/PublishProfiles/FolderProfile1.pubxml`:
    - Changed output directory to `bin/Release/net7.0-windows/win-x86/publish/`.
    - Updated target framework to `.NET 8.0`.
    - Cleaned up XML for consistency.

---

**Impact:**  
- Enables automated builds and releases on GitHub.
- Ensures project targets the latest .NET 8 runtime.
- Simplifies publishing and release management for Windows (x86) self-contained builds.

