### PR TITLE
Add Multi-Architecture Build and Release for Chitti via GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,5 @@
 name: Build and Release Chitti
+
 on:
   push:
     tags:
@@ -8,6 +9,10 @@ on:
 jobs:
   build:
     runs-on: windows-latest
+    strategy:
+      matrix:
+        architecture: [win-x64, win-x86]
+    
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -20,33 +25,60 @@ jobs:
       - name: Restore dependencies
         run: dotnet restore Chitti/Chitti.csproj
         
-      - name: Publish using .pubxml
-        run: dotnet publish Chitti/Chitti.csproj -p:PublishProfile=FolderProfile1
-
+      - name: Publish for ${{ matrix.architecture }}
+        run: |
+          dotnet publish Chitti/Chitti.csproj `
+            --configuration Release `
+            --framework net8.0-windows `
+            --runtime ${{ matrix.architecture }} `
+            --self-contained true `
+            --output "Chitti/bin/Release/net8.0-windows/${{ matrix.architecture }}/publish/"
+        
       - name: Rename executable with architecture
         run: |
-          Copy-Item "Chitti/bin/Release/net7.0-windows/win-x86/publish/Chitti.exe" "Chitti/bin/Release/net7.0-windows/win-x86/publish/Chitti-win-x86.exe"
-              
+          Copy-Item "Chitti/bin/Release/net8.0-windows/${{ matrix.architecture }}/publish/Chitti.exe" "Chitti/bin/Release/net8.0-windows/${{ matrix.architecture }}/publish/Chitti-${{ matrix.architecture }}.exe"
+        
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: chitti-${{ matrix.architecture }}
+          path: Chitti/bin/Release/net8.0-windows/${{ matrix.architecture }}/publish/Chitti-${{ matrix.architecture }}.exe
+
+  release:
+    needs: build
+    runs-on: windows-latest
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: ./artifacts
+          
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
           name: Chitti Release ${{ github.ref_name }}
           tag_name: ${{ github.ref_name }}
           files: |
-            Chitti/bin/Release/net7.0-windows/win-x86/publish/Chitti-win-x86.exe
+            ./artifacts/chitti-win-x64/Chitti-win-x64.exe
+            ./artifacts/chitti-win-x86/Chitti-win-x86.exe
           body: |
             ## Chitti Release ${{ github.ref_name }}
             
             ### What's New
             - Automated build and release
+            - Multi-architecture support (x64 and x86)
+            
+            ### Downloads
+            - **Chitti-win-x64.exe** - For 64-bit Windows systems
+            - **Chitti-win-x86.exe** - For 32-bit Windows systems
             
             ### Installation
-            1. Download `Chitti.exe`
+            1. Download the appropriate executable for your system architecture
             2. Run the executable directly (no installation required)
             
             ### System Requirements
             - Windows 10/11
-            - x64 architecture
+            - Choose x64 version for 64-bit systems, x86 for 32-bit systems
           draft: false
           prerelease: false
         env:

--- a/Chitti/Properties/PublishProfiles/win-x64.pubxml
+++ b/Chitti/Properties/PublishProfiles/win-x64.pubxml
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- https://go.microsoft.com/fwlink/?LinkID=208121. -->
+<Project>
+  <PropertyGroup>
+    <Configuration>Release</Configuration>
+    <Platform>Any CPU</Platform>
+    <PublishDir>bin\Release\net8.0-windows\win-x64\publish\</PublishDir>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <_TargetId>Folder</_TargetId>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <SelfContained>true</SelfContained>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
---
**Title:**  
Add Multi-Architecture Build and Release for Chitti via GitHub Actions

**Description:**  
### Summary of Changes

- **GitHub Actions Workflow Enhancements**
  - Updated `.github/workflows/main.yml` to build and release both x64 and x86 Windows executables using a build matrix.
  - Split build and release into separate jobs for better artifact management.
  - Artifacts for both architectures are uploaded and included in the release.

- **Release Improvements**
  - Release notes and download links now clearly differentiate between 64-bit and 32-bit executables.
  - Enhanced documentation for system requirements and installation.

- **New Publish Profile**
  - Added `Chitti/Properties/PublishProfiles/win-x64.pubxml` for streamlined x64 publishing with .NET 8.

---

**Impact:**  
- Users can now download either x64 or x86 builds depending on their Windows architecture.
- Automated workflow provides simpler, more reliable releases.
- Improved maintainability and clarity for future architecture/platform expansion.
